### PR TITLE
Include `mnesia` in applications

### DIFF
--- a/src/expiring_records.app.src
+++ b/src/expiring_records.app.src
@@ -5,7 +5,8 @@
   {mod, { expiring_records_app, []}},
   {applications,
    [kernel,
-    stdlib
+    stdlib,
+    mnesia
    ]},
   {env,[]},
   {modules, []},


### PR DESCRIPTION
I _thought_ by adding this I could avoid calling `mnesia:start()` before starting your app (creating the table) in the test, but apparently that's not the case...